### PR TITLE
Upgrade JSHint to v2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10.2
 MAINTAINER "EEA: IDM2 A-Team" <eea-edw-a-team-alerts@googlegroups.com>
 
-ENV JSHINT_VERSION=2.9.5
+ENV JSHINT_VERSION=2.10.2
 
 RUN apk add --no-cache --virtual .run-deps nodejs git \
  && npm install -g jshint@$JSHINT_VERSION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.10.2
 MAINTAINER "EEA: IDM2 A-Team" <eea-edw-a-team-alerts@googlegroups.com>
 
 ENV JSHINT_VERSION=2.9.5


### PR DESCRIPTION
This PR updates the image to use the latest version of JSHint, v2.10.x. It also updates the base image to the latest version of Alpine, v3.10.